### PR TITLE
Feature/disable login buttons default

### DIFF
--- a/src/components/Button/styles.tsx
+++ b/src/components/Button/styles.tsx
@@ -18,14 +18,10 @@ export const StyledButton = styled.button<IButton>`
     cursor: pointer;
     ${({ variant }): FlattenSimpleInterpolation => variants[variant]}
     ${({ styles }): string | undefined => styles}
-    ${({ disabled }): FlattenSimpleInterpolation | false | undefined =>
-        disabled &&
-        css`
-            &.disabled {
-                cursor: not-allowed;
-                opacity: 0.6;
-            }
-        `}
+    &:disabled {
+        cursor: ${({ disabled }): string => (disabled ? "not-allowed" : "cursor")};
+        opacity: ${({ disabled }): string => (disabled ? "0.6" : "0")};
+    }
 
     &:hover {
         opacity: 0.6;

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -94,7 +94,11 @@ const LoginPage: React.FC = (): JSX.Element => {
                     type={inputShow ? "text" : "password"}
                     value={passwordObj.value}
                 />
-                <Button variant={variantType.PRIMARY}>{t("Login")}</Button>
+                <Button
+                    disabled={usernameObj.value === "" || passwordObj.value === "" ? true : false}
+                    variant={variantType.PRIMARY}>
+                    {t("Login")}
+                </Button>
             </StyledForm>
         </StyledMainWrapper>
     );

--- a/src/pages/Register/index.tsx
+++ b/src/pages/Register/index.tsx
@@ -66,7 +66,11 @@ const RegisterPage: React.FC = () => {
                     type="password"
                     value={password}
                 />
-                <Button variant={variantType.PRIMARY}>{t("Register")}</Button>
+                <Button
+                    disabled={email === "" || password === "" ? true : false}
+                    variant={variantType.PRIMARY}>
+                    {t("Register")}
+                </Button>
             </StyledForm>
         </StyledMainWrapper>
     );


### PR DESCRIPTION
## Descripcion
Arreglé el estilo disabled del botón, que no funcionaba; y pasé disabled en las páginas Register y Login, cuando alguno de los campos obligatorios está vacío.

## Capturas de pantalla
![image](https://user-images.githubusercontent.com/28830397/126855757-62840309-64d4-49ce-8c61-a4d048d6053e.png)
![image](https://user-images.githubusercontent.com/28830397/126855766-99fd111f-b577-4e6d-8c29-510903db8c8e.png)


## Carta de trello
https://trello.com/c/9oeVviUw/25-front-end-deshabilitar-botones-login-y-register-si-los-campos-est%C3%A1n-vac%C3%ADos
